### PR TITLE
CORE-647 hazelops/tailscale terraform module II created

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ Security scanning is graciously provided by Bridgecrew.
   ```
  **_The tag must be added to the ACL to disable automatic key expiration!_** 
  
-  Default parameter for tag is `tag:server`.
+  Default parameter for tag is `tag:<your-environment>`.
  
   You could found more examples in [Tailscale manual](https://tailscale.com/kb/1068/acl-tags#defining-a-tag).
 
   3. Create AWS SSM Parameter using obtained Tailscale API access token. For example, use the following path pattern: `<env-name>/global/tailscale_api_token`. For more information please refer to [AWS manual](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-create-console.html).
   4. Add data source to Terraform code like in the [example configuration main.tf file](./examples/minimum/main.tf).
-  5. In the module call parameters, set `tailscale_api_token` variable like in the [example configuration main.tf file](./examples/minimum/main.tf).
+  5. In the module call parameters, set `api_token` variable like in the [example configuration main.tf file](./examples/minimum/main.tf).
   6. Alternatively Tailscale API token could be set as string, but this is very unsafe, therefore it is **_highly not recommended_** to do this.
 
 
@@ -123,16 +123,16 @@ No modules.
 | <a name="input_env"></a> [env](#input\_env) | n/a | `string` | n/a | yes |
 | <a name="input_ext_security_groups"></a> [ext\_security\_groups](#input\_ext\_security\_groups) | External security groups to add to the Tailscale instance | `list(any)` | `[]` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Set type of Tailscale instance | `string` | `"t3.nano"` | no |
+| <a name="input_key_ephemeral"></a> [key\_ephemeral](#input\_key\_ephemeral) | Indicates if the key is ephemeral | `bool` | `true` | no |
+| <a name="input_key_expiry"></a> [key\_expiry](#input\_key\_expiry) | The expiry of the key in seconds. Defaults to 7776000 (90 days) | `number` | `7776000` | no |
+| <a name="input_key_preauthorized"></a> [key\_preauthorized](#input\_key\_preauthorized) | Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default | `bool` | `true` | no |
+| <a name="input_key_reusable"></a> [key\_reusable](#input\_key\_reusable) | Indicates if the key is reusable or single-use | `bool` | `true` | no |
 | <a name="input_monitoring_enabled"></a> [monitoring\_enabled](#input\_monitoring\_enabled) | Enable monitoring for the Auto Scaling Group | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Set a name for Tailscale instance | `string` | `"tailscale-router"` | no |
 | <a name="input_public_ip_enabled"></a> [public\_ip\_enabled](#input\_public\_ip\_enabled) | Enable Public IP for Tailscale instance | `bool` | `false` | no |
 | <a name="input_ssm_role_arn"></a> [ssm\_role\_arn](#input\_ssm\_role\_arn) | SSM role to attach to a Tailscale instance | `string` | `"arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets where the Taiscale instance will be placed. It is recommended to use a private subnet for better security. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A device is automatically tagged when it is authenticated with this key | `list(string)` | `[]` | no |
-| <a name="input_tailscale_key_ephemeral"></a> [tailscale\_key\_ephemeral](#input\_tailscale\_key\_ephemeral) | Indicates if the key is ephemeral | `bool` | `true` | no |
-| <a name="input_tailscale_key_expiry"></a> [tailscale\_key\_expiry](#input\_tailscale\_key\_expiry) | The expiry of the key in seconds. Defaults to 7776000 (90 days) | `number` | `7776000` | no |
-| <a name="input_tailscale_key_preauthorized"></a> [tailscale\_key\_preauthorized](#input\_tailscale\_key\_preauthorized) | Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default | `bool` | `true` | no |
-| <a name="input_tailscale_key_reusable"></a> [tailscale\_key\_reusable](#input\_tailscale\_key\_reusable) | Indicates if the key is reusable or single-use | `bool` | `true` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | n/a | `string` | n/a | yes |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Security scanning is graciously provided by Bridgecrew.
     },
   ],
   "tagOwners": {
-    "tag:server": [],
+    "tag:<your-environment>": [],
   },
 }
   ```
@@ -48,6 +48,31 @@ Security scanning is graciously provided by Bridgecrew.
   4. Add data source to Terraform code like in the [example configuration main.tf file](./examples/minimum/main.tf).
   5. In the module call parameters, set `tailscale_api_token` variable like in the [example configuration main.tf file](./examples/minimum/main.tf).
   6. Alternatively Tailscale API token could be set as string, but this is very unsafe, therefore it is **_highly not recommended_** to do this.
+
+
+
+## Possible problems on module destroy:
+
+The following error may occur during module removal:
+```text
+Error: Provider configuration not present
+
+To work with module.tailscale.tailscale_tailnet_key.this (orphan) its
+original provider configuration at
+module.tailscale.provider["registry.terraform.io/tailscale/tailscale"] is
+required, but it has been removed. This occurs when a provider
+configuration is removed while objects created by that provider still exist
+in the state. Re-add the provider configuration to destroy
+module.tailscale.tailscale_tailnet_key.this (orphan), after which you can
+remove the provider configuration again.
+```
+
+To remove it, run the following code:
+
+```shell
+terraform state rm module.tailscale.tailscale_tailnet_key.this
+```
+
 
 ## Requirements
 
@@ -92,6 +117,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of network subnets that are allowed. According to PCI-DSS, CIS AWS and SOC2 providing a default wide-open CIDR is not secure. | `list(string)` | n/a | yes |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | Optional AMI ID for Tailscale instance. Otherwise latest Amazon Linux will be used. | `string` | `""` | no |
+| <a name="input_api_token"></a> [api\_token](#input\_api\_token) | Set Tailscale API access token here | `string` | n/a | yes |
 | <a name="input_asg"></a> [asg](#input\_asg) | Scaling settings of an Auto Scaling Group | `map` | <pre>{<br>  "max_size": 1,<br>  "min_size": 1<br>}</pre> | no |
 | <a name="input_ec2_key_pair_name"></a> [ec2\_key\_pair\_name](#input\_ec2\_key\_pair\_name) | n/a | `string` | n/a | yes |
 | <a name="input_env"></a> [env](#input\_env) | n/a | `string` | n/a | yes |
@@ -102,9 +128,11 @@ No modules.
 | <a name="input_public_ip_enabled"></a> [public\_ip\_enabled](#input\_public\_ip\_enabled) | Enable Public IP for Tailscale instance | `bool` | `false` | no |
 | <a name="input_ssm_role_arn"></a> [ssm\_role\_arn](#input\_ssm\_role\_arn) | SSM role to attach to a Tailscale instance | `string` | `"arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets where the Taiscale instance will be placed. It is recommended to use a private subnet for better security. | `list(string)` | n/a | yes |
-| <a name="input_tailscale_api_token"></a> [tailscale\_api\_token](#input\_tailscale\_api\_token) | Set Tailscale API access token here | `string` | n/a | yes |
-| <a name="input_tailscale_key_expiry"></a> [tailscale\_key\_expiry](#input\_tailscale\_key\_expiry) | The expiry of the key in seconds. Defaults to 7776000 (90 days) | `string` | `7776000` | no |
-| <a name="input_tailscale_tags"></a> [tailscale\_tags](#input\_tailscale\_tags) | A device is automatically tagged when it is authenticated with this key | `list(string)` | <pre>[<br>  "tag:server"<br>]</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A device is automatically tagged when it is authenticated with this key | `list(string)` | `[]` | no |
+| <a name="input_tailscale_key_ephemeral"></a> [tailscale\_key\_ephemeral](#input\_tailscale\_key\_ephemeral) | Indicates if the key is ephemeral | `bool` | `true` | no |
+| <a name="input_tailscale_key_expiry"></a> [tailscale\_key\_expiry](#input\_tailscale\_key\_expiry) | The expiry of the key in seconds. Defaults to 7776000 (90 days) | `number` | `7776000` | no |
+| <a name="input_tailscale_key_preauthorized"></a> [tailscale\_key\_preauthorized](#input\_tailscale\_key\_preauthorized) | Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default | `bool` | `true` | no |
+| <a name="input_tailscale_key_reusable"></a> [tailscale\_key\_reusable](#input\_tailscale\_key\_reusable) | Indicates if the key is reusable or single-use | `bool` | `true` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | n/a | `string` | n/a | yes |
 
 ## Outputs

--- a/data.tf
+++ b/data.tf
@@ -3,7 +3,7 @@ data "template_file" "ec2_user_data" {
   template = file("${path.module}/ec2_user_data.yml.tpl")
 
   vars = {
-    tailscale_auth_key         = var.tailscale_auth_key
+    tailscale_auth_key         = tailscale_tailnet_key.this.key
     tailscale_advertise_routes = join(",", var.allowed_cidr_blocks)
     hostname                   = local.name
   }

--- a/data.tf
+++ b/data.tf
@@ -3,9 +3,9 @@ data "template_file" "ec2_user_data" {
   template = file("${path.module}/ec2_user_data.yml.tpl")
 
   vars = {
-    tailscale_auth_key         = tailscale_tailnet_key.this.key
-    tailscale_advertise_routes = join(",", var.allowed_cidr_blocks)
-    hostname                   = local.name
+    auth_key         = tailscale_tailnet_key.this.key
+    advertise_routes = join(",", var.allowed_cidr_blocks)
+    hostname         = local.name
   }
 }
 

--- a/ec2_user_data.yml.tpl
+++ b/ec2_user_data.yml.tpl
@@ -18,4 +18,4 @@ write_files:
 runcmd:
   - sysctl -p /etc/sysctl.conf
   - systemctl enable --now tailscaled
-  - tailscale up --authkey "${tailscale_auth_key}" --advertise-routes "${tailscale_advertise_routes}" --hostname "${hostname}"
+  - tailscale up --authkey "${auth_key}" --advertise-routes "${advertise_routes}" --hostname "${hostname}"

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -13,20 +13,23 @@ data "aws_ssm_parameter" "tailscale_api_token" {
 }
 
 module "tailscale" {
-  source               = "registry.terraform.io/hazelops/tailscale/aws"
-  version              = "~>0.2"
-  name                 = "tailscale-instance"
-  allowed_cidr_blocks  = [var.vpc_cidr_block]
-  ec2_key_pair_name    = var.aws_key_name
-  env                  = var.env
-  subnets              = var.subnets
-  vpc_id               = var.vpc_id
-  public_ip_enabled    = true
-  ami_id               = "ami-0e1c5d8c23330dee3"
-  instance_type        = "t3.micro"
-  tailscale_api_token  = data.aws_ssm_parameter.tailscale_api_token.value # Please don't store secrets in plain text
-  monitoring_enabled   = true
-  ext_security_groups  = []
-  tailscale_tags       = ["tag:server"]
-  tailscale_key_expiry = 7776000
+  source                      = "registry.terraform.io/hazelops/tailscale/aws"
+  version                     = "~>0.2"
+  name                        = "tailscale-instance"
+  allowed_cidr_blocks         = [var.vpc_cidr_block]
+  ec2_key_pair_name           = var.aws_key_name
+  env                         = var.env
+  subnets                     = var.subnets
+  vpc_id                      = var.vpc_id
+  public_ip_enabled           = true
+  ami_id                      = "ami-0e1c5d8c23330dee3"
+  instance_type               = "t3.micro"
+  tailscale_api_token         = data.aws_ssm_parameter.tailscale_api_token.value # Please don't store secrets in plain text
+  monitoring_enabled          = true
+  ext_security_groups         = []
+  tags                        = ["tag:server"]
+  tailscale_key_expiry        = 7776000
+  tailscale_key_reusable      = true
+  tailscale_key_ephemeral     = true
+  tailscale_key_preauthorized = true
 }

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -13,23 +13,23 @@ data "aws_ssm_parameter" "tailscale_api_token" {
 }
 
 module "tailscale" {
-  source                      = "registry.terraform.io/hazelops/tailscale/aws"
-  version                     = "~>0.2"
-  name                        = "tailscale-instance"
-  allowed_cidr_blocks         = [var.vpc_cidr_block]
-  ec2_key_pair_name           = var.aws_key_name
-  env                         = var.env
-  subnets                     = var.subnets
-  vpc_id                      = var.vpc_id
-  public_ip_enabled           = true
-  ami_id                      = "ami-0e1c5d8c23330dee3"
-  instance_type               = "t3.micro"
-  tailscale_api_token         = data.aws_ssm_parameter.tailscale_api_token.value # Please don't store secrets in plain text
-  monitoring_enabled          = true
-  ext_security_groups         = []
-  tags                        = ["tag:server"]
-  tailscale_key_expiry        = 7776000
-  tailscale_key_reusable      = true
-  tailscale_key_ephemeral     = true
-  tailscale_key_preauthorized = true
+  source              = "registry.terraform.io/hazelops/tailscale/aws"
+  version             = "~>0.2"
+  name                = "tailscale-instance"
+  allowed_cidr_blocks = [var.vpc_cidr_block]
+  ec2_key_pair_name   = var.aws_key_name
+  env                 = var.env
+  subnets             = var.subnets
+  vpc_id              = var.vpc_id
+  public_ip_enabled   = true
+  ami_id              = "ami-0e1c5d8c23330dee3"
+  instance_type       = "t3.micro"
+  tailscale_api_token = data.aws_ssm_parameter.tailscale_api_token.value # Please don't store secrets in plain text
+  monitoring_enabled  = true
+  ext_security_groups = []
+  tags                = ["tag:server"]
+  key_expiry          = 7776000
+  key_reusable        = true
+  key_ephemeral       = true
+  key_preauthorized   = true
 }

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -8,23 +8,25 @@ variable "ssh_key_id" {}
 variable "aws_key_name" {}
 
 # Obtain Tailscale auth key from AWS SSM Parameter Store
-data "aws_ssm_parameter" "tailscale_auth_key" {
-  name = "/${var.env}/global/tailscale_auth_key"
+data "aws_ssm_parameter" "tailscale_api_token" {
+  name = "/${var.env}/global/tailscale_api_token"
 }
 
 module "tailscale" {
-  source              = "registry.terraform.io/hazelops/tailscale/aws"
-  version             = "~>0.1"
-  name                = "tailscale-instance"
-  allowed_cidr_blocks = [var.vpc_cidr_block]
-  ec2_key_pair_name   = var.aws_key_name
-  env                 = var.env
-  subnets             = var.subnets
-  vpc_id              = var.vpc_id
-  public_ip_enabled   = true
-  ami_id              = "ami-0e1c5d8c23330dee3"
-  instance_type       = "t3.micro"
-  tailscale_auth_key  = data.aws_ssm_parameter.tailscale_auth_key.value # Please don't store secrets in plain text
-  monitoring_enabled  = true
-  ext_security_groups = []
+  source               = "registry.terraform.io/hazelops/tailscale/aws"
+  version              = "~>0.2"
+  name                 = "tailscale-instance"
+  allowed_cidr_blocks  = [var.vpc_cidr_block]
+  ec2_key_pair_name    = var.aws_key_name
+  env                  = var.env
+  subnets              = var.subnets
+  vpc_id               = var.vpc_id
+  public_ip_enabled    = true
+  ami_id               = "ami-0e1c5d8c23330dee3"
+  instance_type        = "t3.micro"
+  tailscale_api_token  = data.aws_ssm_parameter.tailscale_api_token.value # Please don't store secrets in plain text
+  monitoring_enabled   = true
+  ext_security_groups  = []
+  tailscale_tags       = ["tag:server"]
+  tailscale_key_expiry = 7776000
 }

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -8,17 +8,17 @@ variable "ssh_key_id" {}
 variable "aws_key_name" {}
 
 # Obtain Tailscale auth key from AWS SSM Parameter Store
-data "aws_ssm_parameter" "tailscale_auth_key" {
-  name = "/${var.env}/global/tailscale_auth_key"
+data "aws_ssm_parameter" "tailscale_api_token" {
+  name = "/${var.env}/global/tailscale_api_token"
 }
 
 module "tailscale" {
   source              = "registry.terraform.io/hazelops/tailscale/aws"
-  version             = "~>0.1"
+  version             = "~>0.2"
   allowed_cidr_blocks = [var.vpc_cidr_block]
   ec2_key_pair_name   = var.aws_key_name
   env                 = var.env
   subnets             = var.subnets
   vpc_id              = var.vpc_id
-  tailscale_auth_key  = data.aws_ssm_parameter.tailscale_auth_key.value # Please don't store secrets in plain text
+  tailscale_api_token = data.aws_ssm_parameter.tailscale_api_token.value # Please don't store secrets in plain text
 }

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -20,5 +20,5 @@ module "tailscale" {
   env                 = var.env
   subnets             = var.subnets
   vpc_id              = var.vpc_id
-  tailscale_api_token = data.aws_ssm_parameter.tailscale_api_token.value # Please don't store secrets in plain text
+  api_token           = data.aws_ssm_parameter.tailscale_api_token.value # Please don't store secrets in plain text
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,3 @@
 provider "tailscale" {
-  api_key = var.tailscale_api_token
+  api_key = var.api_token
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,3 @@
+provider "tailscale" {
+  api_key = var.tailscale_api_token
+}

--- a/tailscale.tf
+++ b/tailscale.tf
@@ -1,8 +1,8 @@
 # Generate Tailscale auth key
 resource "tailscale_tailnet_key" "this" {
-  reusable      = true
-  ephemeral     = true
-  preauthorized = true
+  reusable      = var.tailscale_key_reusable
+  ephemeral     = var.tailscale_key_ephemeral
+  preauthorized = var.tailscale_key_preauthorized
   expiry        = var.tailscale_key_expiry
-  tags          = var.tailscale_tags
+  tags          = local.tags
 }

--- a/tailscale.tf
+++ b/tailscale.tf
@@ -1,8 +1,8 @@
 # Generate Tailscale auth key
 resource "tailscale_tailnet_key" "this" {
-  reusable      = var.tailscale_key_reusable
-  ephemeral     = var.tailscale_key_ephemeral
-  preauthorized = var.tailscale_key_preauthorized
-  expiry        = var.tailscale_key_expiry
+  reusable      = var.key_reusable
+  ephemeral     = var.key_ephemeral
+  preauthorized = var.key_preauthorized
+  expiry        = var.key_expiry
   tags          = local.tags
 }

--- a/tailscale.tf
+++ b/tailscale.tf
@@ -1,0 +1,8 @@
+# Generate Tailscale auth key
+resource "tailscale_tailnet_key" "this" {
+  reusable      = true
+  ephemeral     = true
+  preauthorized = true
+  expiry        = var.tailscale_key_expiry
+  tags          = var.tailscale_tags
+}

--- a/variables.tf
+++ b/variables.tf
@@ -74,25 +74,25 @@ variable "api_token" {
   description = "Set Tailscale API access token here"
 }
 
-variable "tailscale_key_expiry" {
+variable "key_expiry" {
   type        = number
   default     = 7776000
   description = "The expiry of the key in seconds. Defaults to 7776000 (90 days)"
 }
 
-variable "tailscale_key_reusable" {
+variable "key_reusable" {
   type        = bool
   default     = true
   description = "Indicates if the key is reusable or single-use"
 }
 
-variable "tailscale_key_ephemeral" {
+variable "key_ephemeral" {
   type        = bool
   default     = true
   description = "Indicates if the key is ephemeral"
 }
 
-variable "tailscale_key_preauthorized" {
+variable "key_preauthorized" {
   type        = bool
   default     = true
   description = "Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default"

--- a/variables.tf
+++ b/variables.tf
@@ -69,23 +69,42 @@ variable "monitoring_enabled" {
   description = "Enable monitoring for the Auto Scaling Group"
 }
 
-variable "tailscale_api_token" {
+variable "api_token" {
   type        = string
   description = "Set Tailscale API access token here"
 }
 
 variable "tailscale_key_expiry" {
-  type        = string
+  type        = number
   default     = 7776000
   description = "The expiry of the key in seconds. Defaults to 7776000 (90 days)"
 }
 
-variable "tailscale_tags" {
+variable "tailscale_key_reusable" {
+  type        = bool
+  default     = true
+  description = "Indicates if the key is reusable or single-use"
+}
+
+variable "tailscale_key_ephemeral" {
+  type        = bool
+  default     = true
+  description = "Indicates if the key is ephemeral"
+}
+
+variable "tailscale_key_preauthorized" {
+  type        = bool
+  default     = true
+  description = "Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default"
+}
+
+variable "tags" {
   type        = list(string)
-  default     = ["tag:server"]
+  default     = []
   description = "A device is automatically tagged when it is authenticated with this key"
 }
 
 locals {
   name = "${var.env}-${var.name}"
+  tags = concat(["tag:${var.env}"], var.tags)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "ec2_key_pair_name" {
 }
 
 variable "subnets" {
-  type = list(string)
+  type        = list(string)
   description = "Subnets where the Taiscale instance will be placed. It is recommended to use a private subnet for better security."
 }
 
@@ -24,11 +24,6 @@ variable "name" {
   type        = string
   default     = "tailscale-router"
   description = "Set a name for Tailscale instance"
-}
-
-variable "tailscale_auth_key" {
-  type        = string
-  description = "Set Tailscale authorization key here. To create Tailscale authorization key, please visit: https://tailscale.com/kb/1085/auth-keys"
 }
 
 variable "instance_type" {
@@ -72,6 +67,23 @@ variable "monitoring_enabled" {
   type        = bool
   default     = true
   description = "Enable monitoring for the Auto Scaling Group"
+}
+
+variable "tailscale_api_token" {
+  type        = string
+  description = "Set Tailscale API access token here"
+}
+
+variable "tailscale_key_expiry" {
+  type        = string
+  default     = 7776000
+  description = "The expiry of the key in seconds. Defaults to 7776000 (90 days)"
+}
+
+variable "tailscale_tags" {
+  type        = list(string)
+  default     = ["tag:server"]
+  description = "A device is automatically tagged when it is authenticated with this key"
 }
 
 locals {

--- a/versions.tf
+++ b/versions.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/local"
       version = "~> 1.2"
     }
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = "0.13.13"
+    }
   }
   required_version = ">=1.2.0"
 }


### PR DESCRIPTION
#### What's new:

1. Added Tailscale proider for instance key creation and future updates
2. Added Tailscale instance key creation through Terraform resource

#### Testing done:

Tag added, key expiration is disabled

<img width="1288" alt="Screenshot 2023-12-27 at 13 24 16" src="https://github.com/hazelops/terraform-aws-tailscale/assets/24703846/410be587-0ec2-4244-a8f4-f099d51c7f26">


<img width="516" alt="Screenshot 2023-12-27 at 13 29 47" src="https://github.com/hazelops/terraform-aws-tailscale/assets/24703846/6984b35c-e08f-474a-9489-069facd8000d">
