### PR TITLE
CORE-649 AMI set to the latest version in the launch template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ resource "aws_launch_template" "this" {
   instance_type                        = var.instance_type
   key_name                             = var.ec2_key_pair_name
   user_data                            = base64encode(data.template_file.ec2_user_data.rendered)
+  update_default_version               = true
   monitoring {
     enabled = var.monitoring_enabled
   }


### PR DESCRIPTION
#### What's new:

 -  Added  `update_default_version = true` to the launch template Terraform source 
   This will make terraform to set latest version as default one.


#### Testing done:

First deploy:
<img width="1318" alt="Screenshot 2024-01-05 at 11 25 52" src="https://github.com/hazelops/terraform-aws-tailscale/assets/24703846/5f936984-eec8-4963-a39c-ddee5de13a8f">

After changes to template:

<img width="1318" alt="Screenshot 2024-01-05 at 11 32 21" src="https://github.com/hazelops/terraform-aws-tailscale/assets/24703846/20d4799d-e0e0-4dbe-8e7e-720db1c5ef27">

