### PR TITLE
Refactor tags in Tailscale configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,24 +93,23 @@ terraform state rm module.tailscale.tailscale_tailnet_key.this
 ```
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                      | Version  |
-|---------------------------------------------------------------------------|----------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.2.0  |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >=4.30.0 |
-| <a name="requirement_local"></a> [local](#requirement\_local)             | ~> 1.2   |
-| <a name="requirement_tailscale"></a> [tailscale](#requirement\_tailscale) | 0.13.13  |
-| <a name="requirement_template"></a> [template](#requirement\_template)    | >=2.2    |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=4.30.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 1.2 |
+| <a name="requirement_tailscale"></a> [tailscale](#requirement\_tailscale) | 0.13.13 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | >=2.2 |
 
 ## Providers
 
-| Name                                                                | Version  |
-|---------------------------------------------------------------------|----------|
-| <a name="provider_aws"></a> [aws](#provider\_aws)                   | >=4.30.0 |
-| <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | 0.13.13  |
-| <a name="provider_template"></a> [template](#provider\_template)    | >=2.2    |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >=4.30.0 |
+| <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | 0.13.13 |
+| <a name="provider_template"></a> [template](#provider\_template) | >=2.2 |
 
 ## Modules
 
@@ -118,49 +117,49 @@ No modules.
 
 ## Resources
 
-| Name                                                                                                                                          | Type        |
-|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| [aws_autoscaling_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group)                   | resource    |
-| [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile)             | resource    |
-| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)                                     | resource    |
-| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource    |
-| [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template)                       | resource    |
-| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group)                         | resource    |
-| [tailscale_tailnet_key.this](https://registry.terraform.io/providers/tailscale/tailscale/0.13.13/docs/resources/tailnet_key)                  | resource    |
-| [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami)                                            | data source |
-| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)            | data source |
-| [template_file.ec2_user_data](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file)                       | data source |
+| Name | Type |
+|------|------|
+| [aws_autoscaling_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
+| [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [tailscale_tailnet_key.this](https://registry.terraform.io/providers/tailscale/tailscale/0.13.13/docs/resources/tailnet_key) | resource |
+| [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [template_file.ec2_user_data](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 
-| Name                                                                                            | Description                                                                                                                        | Type           | Default                                                      | Required |
-|-------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|----------------|--------------------------------------------------------------|:--------:|
-| <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of network subnets that are allowed. According to PCI-DSS, CIS AWS and SOC2 providing a default wide-open CIDR is not secure. | `list(string)` | n/a                                                          |   yes    |
-| <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id)                                          | Optional AMI ID for Tailscale instance. Otherwise latest Amazon Linux will be used.                                                | `string`       | `""`                                                         |    no    |
-| <a name="input_api_token"></a> [api\_token](#input\_api\_token)                                 | Set Tailscale API access token here                                                                                                | `string`       | n/a                                                          |   yes    |
-| <a name="input_asg"></a> [asg](#input\_asg)                                                     | Scaling settings of an Auto Scaling Group                                                                                          | `map`          | <pre>{<br>  "max_size": 1,<br>  "min_size": 1<br>}</pre>     |    no    |
-| <a name="input_ec2_key_pair_name"></a> [ec2\_key\_pair\_name](#input\_ec2\_key\_pair\_name)     | n/a                                                                                                                                | `string`       | n/a                                                          |   yes    |
-| <a name="input_env"></a> [env](#input\_env)                                                     | n/a                                                                                                                                | `string`       | n/a                                                          |   yes    |
-| <a name="input_ext_security_groups"></a> [ext\_security\_groups](#input\_ext\_security\_groups) | External security groups to add to the Tailscale instance                                                                          | `list(any)`    | `[]`                                                         |    no    |
-| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type)                     | Set type of Tailscale instance                                                                                                     | `string`       | `"t3.nano"`                                                  |    no    |
-| <a name="input_key_ephemeral"></a> [key\_ephemeral](#input\_key\_ephemeral)                     | Indicates if the key is ephemeral                                                                                                  | `bool`         | `true`                                                       |    no    |
-| <a name="input_key_expiry"></a> [key\_expiry](#input\_key\_expiry)                              | The expiry of the key in seconds. Defaults to 7776000 (90 days)                                                                    | `number`       | `7776000`                                                    |    no    |
-| <a name="input_key_preauthorized"></a> [key\_preauthorized](#input\_key\_preauthorized)         | Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default                      | `bool`         | `true`                                                       |    no    |
-| <a name="input_key_reusable"></a> [key\_reusable](#input\_key\_reusable)                        | Indicates if the key is reusable or single-use                                                                                     | `bool`         | `true`                                                       |    no    |
-| <a name="input_monitoring_enabled"></a> [monitoring\_enabled](#input\_monitoring\_enabled)      | Enable monitoring for the Auto Scaling Group                                                                                       | `bool`         | `true`                                                       |    no    |
-| <a name="input_name"></a> [name](#input\_name)                                                  | Set a name for Tailscale instance                                                                                                  | `string`       | `"tailscale-router"`                                         |    no    |
-| <a name="input_public_ip_enabled"></a> [public\_ip\_enabled](#input\_public\_ip\_enabled)       | Enable Public IP for Tailscale instance                                                                                            | `bool`         | `false`                                                      |    no    |
-| <a name="input_ssm_role_arn"></a> [ssm\_role\_arn](#input\_ssm\_role\_arn)                      | SSM role to attach to a Tailscale instance                                                                                         | `string`       | `"arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"` |    no    |
-| <a name="input_subnets"></a> [subnets](#input\_subnets)                                         | Subnets where the Taiscale instance will be placed. It is recommended to use a private subnet for better security.                 | `list(string)` | n/a                                                          |   yes    |
-| <a name="input_tags"></a> [tags](#input\_tags)                                                  | A device is automatically tagged when it is authenticated with this key                                                            | `list(string)` | `[]`                                                         |    no    |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id)                                          | n/a                                                                                                                                | `string`       | n/a                                                          |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of network subnets that are allowed. According to PCI-DSS, CIS AWS and SOC2 providing a default wide-open CIDR is not secure. | `list(string)` | n/a | yes |
+| <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | Optional AMI ID for Tailscale instance. Otherwise latest Amazon Linux will be used. One might want to lock this down to avoid unexpected upgrades. | `string` | `""` | no |
+| <a name="input_api_token"></a> [api\_token](#input\_api\_token) | Tailscale API access token | `string` | n/a | yes |
+| <a name="input_asg"></a> [asg](#input\_asg) | Scaling settings of an Auto Scaling Group | `map(any)` | <pre>{<br/>  "max_size": 1,<br/>  "min_size": 1<br/>}</pre> | no |
+| <a name="input_ec2_key_pair_name"></a> [ec2\_key\_pair\_name](#input\_ec2\_key\_pair\_name) | EC2 key pair name to use for Tailscale instance | `string` | n/a | yes |
+| <a name="input_env"></a> [env](#input\_env) | Environment name (typically dev/prod) | `string` | n/a | yes |
+| <a name="input_ext_security_groups"></a> [ext\_security\_groups](#input\_ext\_security\_groups) | External security groups to add to the Tailscale instance | `list(any)` | `[]` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Type of Tailscale instance | `string` | `"t3.nano"` | no |
+| <a name="input_key_ephemeral"></a> [key\_ephemeral](#input\_key\_ephemeral) | Indicates whether the key is ephemeral | `bool` | `true` | no |
+| <a name="input_key_expiry"></a> [key\_expiry](#input\_key\_expiry) | Expiry of the key in seconds. Defaults to 7776000 (90 days) | `number` | `7776000` | no |
+| <a name="input_key_preauthorized"></a> [key\_preauthorized](#input\_key\_preauthorized) | Determines whether or not the machines authenticated by the key will be authorized for the Tailnet by default | `bool` | `true` | no |
+| <a name="input_key_reusable"></a> [key\_reusable](#input\_key\_reusable) | Indicates whether the key is reusable | `bool` | `true` | no |
+| <a name="input_monitoring_enabled"></a> [monitoring\_enabled](#input\_monitoring\_enabled) | Whether to enable monitoring for the Auto Scaling Group | `bool` | `true` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name for Tailscale instance | `string` | `"tailscale-router"` | no |
+| <a name="input_public_ip_enabled"></a> [public\_ip\_enabled](#input\_public\_ip\_enabled) | Wheter to enable a public IP for Tailscale instance | `bool` | `false` | no |
+| <a name="input_ssm_role_arn"></a> [ssm\_role\_arn](#input\_ssm\_role\_arn) | SSM role to attach to a Tailscale instance | `string` | `"arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"` | no |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets where the Taiscale instance will be placed. It is recommended to use a private subnet for better security. | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | AWS tags for the Tailscale instance | `map(string)` | `{}` | no |
+| <a name="input_tailscale_tags"></a> [tailscale\_tags](#input\_tailscale\_tags) | List of Tailscale tags for the Tailnet device. It would be automatically tagged when it is authenticated with this key | `set(string)` | `[]` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the Tailscale instance will be placed | `string` | n/a | yes |
 
 ## Outputs
 
-| Name                                                                                                 | Description |
-|------------------------------------------------------------------------------------------------------|-------------|
-| <a name="output_autoscaling_group_id"></a> [autoscaling\_group\_id](#output\_autoscaling\_group\_id) | n/a         |
-| <a name="output_name"></a> [name](#output\_name)                                                     | n/a         |
-| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id)          | n/a         |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_autoscaling_group_id"></a> [autoscaling\_group\_id](#output\_autoscaling\_group\_id) | n/a |
+| <a name="output_name"></a> [name](#output\_name) | n/a |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | n/a |
 <!-- END_TF_DOCS -->

--- a/data.tf
+++ b/data.tf
@@ -1,4 +1,4 @@
-# Generate userdata for Tailscale instance
+# Tailscale instance user data
 data "template_file" "ec2_user_data" {
   template = file("${path.module}/templates/ec2_user_data.tpl.yml")
 
@@ -9,7 +9,7 @@ data "template_file" "ec2_user_data" {
   }
 }
 
-# Get latest AMI info for Amazon Linux 2023
+# Instance AMI
 data "aws_ami" "this" {
   most_recent = true
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,3 @@
 locals {
   name = "${var.env}-${var.name}"
-  tags = concat(["tag:${var.env}"], var.tags)
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
-# Create Tailscale autoscaling group
+# Tailscale autoscaling group
 resource "aws_autoscaling_group" "this" {
-  name = "${var.env}-tailscale"
+  name                = local.name
   vpc_zone_identifier = var.subnets
   min_size            = var.asg["max_size"]
   max_size            = var.asg["min_size"]
@@ -14,9 +14,9 @@ resource "aws_autoscaling_group" "this" {
   }
 }
 
-# Create Tailscale launch template
+# Tailscale launch template
 resource "aws_launch_template" "this" {
-  name = "${var.env}-tailscale-template"
+  name = local.name
   iam_instance_profile {
     name = aws_iam_instance_profile.this.name
   }
@@ -33,8 +33,17 @@ resource "aws_launch_template" "this" {
     associate_public_ip_address = var.public_ip_enabled
     security_groups             = concat(var.ext_security_groups, [aws_security_group.this.id])
   }
-  tags = {
+  tags = merge({
     Name      = local.name
     TailScale = "enabled"
-  }
+  }, var.tags)
+}
+
+# Tailscale key
+resource "tailscale_tailnet_key" "this" {
+  reusable      = var.key_reusable
+  ephemeral     = var.key_ephemeral
+  preauthorized = var.key_preauthorized
+  expiry        = var.key_expiry
+  tags          = concat(["tag:${var.env}"], var.tailscale_tags)
 }

--- a/tailscale.tf
+++ b/tailscale.tf
@@ -1,8 +1,0 @@
-# Generate Tailscale auth key
-resource "tailscale_tailnet_key" "this" {
-  reusable      = var.key_reusable
-  ephemeral     = var.key_ephemeral
-  preauthorized = var.key_preauthorized
-  expiry        = var.key_expiry
-  tags          = local.tags
-}

--- a/variables.tf
+++ b/variables.tf
@@ -102,8 +102,14 @@ variable "key_preauthorized" {
   description = "Determines whether or not the machines authenticated by the key will be authorized for the Tailnet by default"
 }
 
-variable "tags" {
+variable "tailscale_tags" {
   type        = list(string)
   default     = []
-  description = "List of tags for the Tailnet device. It would be automatically tagged when it is authenticated with this key"
+  description = "List of Tailscale tags for the Tailnet device. It would be automatically tagged when it is authenticated with this key"
+}
+
+variable "tags" {
+    type        = map(string)
+    default     = {}
+    description = "AWS tags for the Tailscale instance"
 }


### PR DESCRIPTION
# What's in this PR
- Move Tailscale resource
- Update userdata comments for clarity
- Rename tags variable to tailscale_tags
- Add AWS tags for Tailscale instance
- Consolidate tagging logic in locals
- Improve README formatting for clarity