### PR TITLE
CORE-866 Providers local and template removed/Readme updated/data replaced with templatefile function

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,7 @@ terraform state rm module.tailscale.tailscale_tailnet_key.this
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=4.30.0 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 1.2 |
 | <a name="requirement_tailscale"></a> [tailscale](#requirement\_tailscale) | 0.13.13 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >=2.2 |
 
 ## Providers
 
@@ -109,7 +107,6 @@ terraform state rm module.tailscale.tailscale_tailnet_key.this
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >=4.30.0 |
 | <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | 0.13.13 |
-| <a name="provider_template"></a> [template](#provider\_template) | >=2.2 |
 
 ## Modules
 
@@ -128,7 +125,6 @@ No modules.
 | [tailscale_tailnet_key.this](https://registry.terraform.io/providers/tailscale/tailscale/0.13.13/docs/resources/tailnet_key) | resource |
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [template_file.ec2_user_data](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 
@@ -137,7 +133,7 @@ No modules.
 | <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of network subnets that are allowed. According to PCI-DSS, CIS AWS and SOC2 providing a default wide-open CIDR is not secure. | `list(string)` | n/a | yes |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | Optional AMI ID for Tailscale instance. Otherwise latest Amazon Linux will be used. One might want to lock this down to avoid unexpected upgrades. | `string` | `""` | no |
 | <a name="input_api_token"></a> [api\_token](#input\_api\_token) | Tailscale API access token | `string` | n/a | yes |
-| <a name="input_asg"></a> [asg](#input\_asg) | Scaling settings of an Auto Scaling Group | `map(any)` | <pre>{<br/>  "max_size": 1,<br/>  "min_size": 1<br/>}</pre> | no |
+| <a name="input_asg"></a> [asg](#input\_asg) | Scaling settings of an Auto Scaling Group | `map(any)` | <pre>{<br>  "max_size": 1,<br>  "min_size": 1<br>}</pre> | no |
 | <a name="input_ec2_key_pair_name"></a> [ec2\_key\_pair\_name](#input\_ec2\_key\_pair\_name) | EC2 key pair name to use for Tailscale instance | `string` | n/a | yes |
 | <a name="input_env"></a> [env](#input\_env) | Environment name (typically dev/prod) | `string` | n/a | yes |
 | <a name="input_ext_security_groups"></a> [ext\_security\_groups](#input\_ext\_security\_groups) | External security groups to add to the Tailscale instance | `list(any)` | `[]` | no |
@@ -152,7 +148,7 @@ No modules.
 | <a name="input_ssm_role_arn"></a> [ssm\_role\_arn](#input\_ssm\_role\_arn) | SSM role to attach to a Tailscale instance | `string` | `"arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets where the Taiscale instance will be placed. It is recommended to use a private subnet for better security. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | AWS tags for the Tailscale instance | `map(string)` | `{}` | no |
-| <a name="input_tailscale_tags"></a> [tailscale\_tags](#input\_tailscale\_tags) | List of Tailscale tags for the Tailnet device. It would be automatically tagged when it is authenticated with this key | `set(string)` | `[]` | no |
+| <a name="input_tailscale_tags"></a> [tailscale\_tags](#input\_tailscale\_tags) | List of Tailscale tags for the Tailnet device. It would be automatically tagged when it is authenticated with this key | `list(string)` | `[]` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the Tailscale instance will be placed | `string` | n/a | yes |
 
 ## Outputs

--- a/data.tf
+++ b/data.tf
@@ -1,14 +1,3 @@
-# Tailscale instance user data
-data "template_file" "ec2_user_data" {
-  template = file("${path.module}/templates/ec2_user_data.tpl.yml")
-
-  vars = {
-    auth_key         = tailscale_tailnet_key.this.key
-    advertise_routes = join(",", var.allowed_cidr_blocks)
-    hostname         = local.name
-  }
-}
-
 # Instance AMI
 data "aws_ami" "this" {
   most_recent = true

--- a/main.tf
+++ b/main.tf
@@ -36,8 +36,12 @@ resource "aws_launch_template" "this" {
   instance_initiated_shutdown_behavior = "terminate"
   instance_type                        = var.instance_type
   key_name                             = var.ec2_key_pair_name
-  user_data                            = base64encode(data.template_file.ec2_user_data.rendered)
-  update_default_version               = true
+  user_data = base64encode(templatefile("${path.module}/templates/ec2_user_data.tpl.yml", {
+    auth_key         = tailscale_tailnet_key.this.key
+    advertise_routes = join(",", var.allowed_cidr_blocks)
+    hostname         = local.name
+  }))
+  update_default_version = true
   monitoring {
     enabled = var.monitoring_enabled
   }

--- a/versions.tf
+++ b/versions.tf
@@ -4,14 +4,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">=4.30.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">=2.2"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = "~> 1.2"
-    }
     tailscale = {
       source  = "tailscale/tailscale"
       version = "0.13.13"


### PR DESCRIPTION
#### What's new:

 - Providers local and template removed
 - Data source replaced with templatefile function to remove template provider usage
 - Readme updated

#### Testing done:

Terraform init & deploy with module before update:
<img width="925" alt="Screenshot 2025-03-27 at 01 24 56" src="https://github.com/user-attachments/assets/bf635624-ee91-489f-b565-0179df54b49c" />
<img width="903" alt="Screenshot 2025-03-27 at 01 35 20" src="https://github.com/user-attachments/assets/6e4ba985-c2da-4312-b36d-23443623450d" />

Upgrade from old version to new tested: no errors
<img width="1680" alt="Screenshot 2025-03-27 at 01 44 34" src="https://github.com/user-attachments/assets/8aaf8459-988f-4bef-ba1f-e6aab22b22f1" />
<img width="912" alt="Screenshot 2025-03-27 at 01 46 24" src="https://github.com/user-attachments/assets/e95692e8-5949-4adb-acec-9dedd1829118" />

List of providers after update:
<img width="1086" alt="Screenshot 2025-03-27 at 01 47 02" src="https://github.com/user-attachments/assets/de34bc03-6591-454a-b48f-a5e586e71296" />

Terraform init and deploy new module version from scratch:
<img width="850" alt="Screenshot 2025-03-27 at 02 07 23" src="https://github.com/user-attachments/assets/c7eea1aa-ae63-46a8-ba67-9332e245ce4b" />
<img width="922" alt="Screenshot 2025-03-27 at 01 54 59" src="https://github.com/user-attachments/assets/2a127257-a9c4-4e3e-bfc2-82f431065d32" />

New module version still creates Tailscale instances:
<img width="1170" alt="Screenshot 2025-03-27 at 02 07 50" src="https://github.com/user-attachments/assets/1382c24c-d7e2-4587-b7a6-6f87197e0123" />

