### PR TITLE
CORE-868 Tailscale v2 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ This module is used to deploy a [Tailscale](https://tailscale.com) router instan
 Tailscale Cloud.
 
 Module logic is the following:
-1. Connect to TailScale API using the Terraform Provider and Tailscale api token.
-2. Generate TailScale Auth Key and place it into the instance.
+1. Connect to Tailscale API using the Terraform Provider and Tailscale api token.
+2. Generate Tailscale Auth Key and place it into the instance.
 3. Create an Autoscale Group with a single instance using and connect it to the TailScale network.
 
 ## Usage
@@ -14,7 +14,7 @@ _Please refer to [Tailscale Configuration](#tailscale-configuration) first_
 ```terraform
 module "tailscale" {
   source            = "registry.terraform.io/hazelops/tailscale/aws"
-  version           = "~>0.2"
+  version           = "~>2.0"
   allowed_cidr_blocks = ["0.0.0.0/0"] # Please lock this down to your specific CIDR
   ec2_key_pair_name = "default-key"
   env               = "prod"
@@ -91,6 +91,19 @@ To remove it, run the following code:
 ```shell
 terraform state rm module.tailscale.tailscale_tailnet_key.this
 ```
+
+## Migration from v1.x to v2.x
+
+In order to upgrade module to v2.x, please follow instructions:
+ 
+ Upgrade provider:
+
+```bash
+ize terraform init -upgrade
+```
+
+ Then deploy as usual. 
+
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -92,19 +92,6 @@ To remove it, run the following code:
 terraform state rm module.tailscale.tailscale_tailnet_key.this
 ```
 
-## Migration from v1.x to v2.x
-
-In order to upgrade module to v2.x, please follow instructions:
- 
- Upgrade provider:
-
-```bash
-ize terraform init -upgrade
-```
-
- Then deploy as usual. 
-
-
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ terraform state rm module.tailscale.tailscale_tailnet_key.this
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=4.30.0 |
-| <a name="requirement_tailscale"></a> [tailscale](#requirement\_tailscale) | 0.13.13 |
+| <a name="requirement_tailscale"></a> [tailscale](#requirement\_tailscale) | 0.18 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >=4.30.0 |
-| <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | 0.13.13 |
+| <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | 0.18 |
 
 ## Modules
 
@@ -122,7 +122,7 @@ No modules.
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [tailscale_tailnet_key.this](https://registry.terraform.io/providers/tailscale/tailscale/0.13.13/docs/resources/tailnet_key) | resource |
+| [tailscale_tailnet_key.this](https://registry.terraform.io/providers/tailscale/tailscale/0.18/docs/resources/tailnet_key) | resource |
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
@@ -137,7 +137,7 @@ No modules.
 | <a name="input_ec2_key_pair_name"></a> [ec2\_key\_pair\_name](#input\_ec2\_key\_pair\_name) | EC2 key pair name to use for Tailscale instance | `string` | n/a | yes |
 | <a name="input_env"></a> [env](#input\_env) | Environment name (typically dev/prod) | `string` | n/a | yes |
 | <a name="input_ext_security_groups"></a> [ext\_security\_groups](#input\_ext\_security\_groups) | External security groups to add to the Tailscale instance | `list(any)` | `[]` | no |
-| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Type of Tailscale instance | `string` | `"t3.nano"` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Type of Tailscale instance | `string` | `"t4g.nano"` | no |
 | <a name="input_key_ephemeral"></a> [key\_ephemeral](#input\_key\_ephemeral) | Indicates whether the key is ephemeral | `bool` | `true` | no |
 | <a name="input_key_expiry"></a> [key\_expiry](#input\_key\_expiry) | Expiry of the key in seconds. Defaults to 7776000 (90 days) | `number` | `7776000` | no |
 | <a name="input_key_preauthorized"></a> [key\_preauthorized](#input\_key\_preauthorized) | Determines whether or not the machines authenticated by the key will be authorized for the Tailnet by default | `bool` | `true` | no |

--- a/data.tf
+++ b/data.tf
@@ -1,10 +1,11 @@
 # Instance AMI
+# Get latest AMI info for Amazon Linux
 data "aws_ami" "this" {
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["al2023-ami-ecs-hvm-2023*-*-arm64"]
+    values = ["al2023-ami-2023*-*-${local.instance_arch}"]
   }
 
   filter {

--- a/data.tf
+++ b/data.tf
@@ -4,7 +4,7 @@ data "aws_ami" "this" {
 
   filter {
     name   = "name"
-    values = ["al2023-ami-2023*-*-x86_64"]
+    values = ["al2023-ami-ecs-hvm-2023*-*-arm64"]
   }
 
   filter {

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -14,7 +14,7 @@ data "aws_ssm_parameter" "tailscale_api_token" {
 
 module "tailscale" {
   source              = "registry.terraform.io/hazelops/tailscale/aws"
-  version             = "~>0.2"
+  version             = "~>2.0"
   name                = "tailscale-instance"
   allowed_cidr_blocks = [var.vpc_cidr_block]
   ec2_key_pair_name   = var.aws_key_name
@@ -23,7 +23,7 @@ module "tailscale" {
   vpc_id              = var.vpc_id
   public_ip_enabled   = true
   ami_id              = "ami-0e1c5d8c23330dee3"
-  instance_type       = "t3.micro"
+  instance_type       = "t4g.nano"
   tailscale_api_token = data.aws_ssm_parameter.tailscale_api_token.value # Please don't store secrets in plain text
   monitoring_enabled  = true
   ext_security_groups = []

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -14,7 +14,7 @@ data "aws_ssm_parameter" "tailscale_api_token" {
 
 module "tailscale" {
   source              = "registry.terraform.io/hazelops/tailscale/aws"
-  version             = "~>0.2"
+  version             = "~>2.0"
   allowed_cidr_blocks = [var.vpc_cidr_block]
   ec2_key_pair_name   = var.aws_key_name
   env                 = var.env

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,4 @@
 locals {
   name = "${var.env}-${var.name}"
+  instance_arch = can(regex("\\w\\dg\\..*", var.instance_type)) ? "arm64" : "x86_64"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "name" {
 
 variable "instance_type" {
   type        = string
-  default     = "t3.nano"
+  default     = "t4g.nano"
   description = "Type of Tailscale instance"
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     tailscale = {
       source  = "tailscale/tailscale"
-      version = "0.13.13"
+      version = "0.18"
     }
   }
   required_version = ">=1.2.0"


### PR DESCRIPTION
####  What's new

 - Provider updated to 0.18
 - Instance moved to ARM64 version by default
 - Added ability to use ARM64 or X86-64 AWS instances

#### Testing done:

Update from v1.x to v2.x successful. (For migration info, please refer to Readme)
<img width="503" alt="Screenshot 2025-04-02 at 17 22 21" src="https://github.com/user-attachments/assets/6914aadb-fed4-439b-9d65-539e39df4a6a" />

Works in ARM64 instance:
<img width="555" alt="Screenshot 2025-04-02 at 17 30 24" src="https://github.com/user-attachments/assets/362b3bdf-4471-476e-8b4c-bdf832f0957b" />

Works in X86-64 instance:
<img width="511" alt="Screenshot 2025-04-02 at 17 26 49" src="https://github.com/user-attachments/assets/2d7085eb-a233-4217-a86a-aa514999d857" />

#### Migration from v1.x to v2.x

In order to upgrade module to v2.x, please follow instructions:
 
 Upgrade provider:

```bash
ize terraform init -upgrade
```

 Then deploy as usual. 

