### PR TITLE
Tailscale V3 module created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+## 3.0.0 (2026-06-11)
+
+### Breaking Changes
+
+- **OAuth authentication required.** The `api_token` variable has been removed.
+  The module now uses `tailscale_oauth_client_id` and `tailscale_oauth_client_secret`
+  for provider authentication.
+
+### Migration Steps
+
+1. Create an OAuth client in the Tailscale Admin Console:
+   Admin Console → Settings → OAuth clients → Generate OAuth client.
+   Scope: `auth_keys` — Write. Select the tags used by the module (e.g. `tag:<env>`).
+2. Store the OAuth client ID and secret in AWS SSM Parameter Store
+   (e.g. `/<env>/global/tailscale_oauth_client_id` and `/<env>/global/tailscale_oauth_client_secret`).
+3. Update your module call: replace `api_token` with `tailscale_oauth_client_id`
+   and `tailscale_oauth_client_secret`.
+4. Run `terraform init -upgrade` to pull the updated tailscale provider.
+5. Run `terraform plan` to verify — expect no destructive changes to infrastructure
+   (the ASG and launch template remain unchanged).
+6. Revoke the old Tailscale API token.
+
+### Features
+
+- **Fix ASG min/max bug.** `min_size` and `max_size` were swapped — corrected.
+- **HA support.** Set `asg = { min_size = 2, max_size = 2 }` with subnets in two AZs
+  for automatic failover (~15s).
+- **Optional Datadog monitoring.** Set `datadog_enabled = true` and
+  `datadog_api_key` to install Datadog Agent with a custom Tailscale
+  health check (gauges: `tailscale.self.online`, `tailscale.peers.count`,
+  `tailscale.health.issues`; service check: `tailscale.up`).
+- Tailscale provider updated to `~> 0.29`.
+
+### Internal
+
+- Simplified output syntax.
+- Updated examples for v3.
+- Fixed Tailscale yum repo URL to match Amazon Linux 2023 AMI.
+- Fixed `ssm_role_arn` default: replaced deprecated `AmazonEC2RoleforSSM` with `AmazonSSMManagedInstanceCore`.

--- a/README.md
+++ b/README.md
@@ -112,10 +112,31 @@ module "tailscale" {
 ```
 
 This installs Datadog Agent 7 and a custom check that emits:
+
 - `tailscale.self.online` (gauge, 0/1)
 - `tailscale.peers.count` (gauge)
-- `tailscale.health.issues` (gauge)
-- `tailscale.up` (service check, OK or CRITICAL)
+- `tailscale.peers.online` / `tailscale.peers.direct` / `tailscale.peers.relayed` (gauges) — tailnet-wide aggregates
+- `tailscale.peer.online` / `tailscale.peer.rx_bytes` / `tailscale.peer.tx_bytes` / `tailscale.peer.direct` / `tailscale.peer.last_handshake_age_seconds` (gauges, tagged `peer:<hostname>`)
+- `tailscale.routes.primary_count` (gauge) — subnets this node serves as primary subnet router (approved and active)
+- `tailscale.health.issues` (gauge) — total count of Tailscale health messages
+- `tailscale.up` (service check)
+
+### Service check states
+
+The `tailscale.up` service check distinguishes real failures from benign health
+warnings, so it does not page on issues that are normal for a subnet router:
+
+| Node state | Health messages | `tailscale.up` |
+|------------|-----------------|----------------|
+| Online | none | `OK` |
+| Online | only benign (e.g. "advertising routes but `--accept-routes` is false") | `OK` |
+| Online | real issue present (e.g. DERP region unreachable) | `WARNING` (message lists the real issues only) |
+| Offline | any | `CRITICAL` |
+
+Benign messages are filtered out before evaluation, so a subnet router that
+advertises routes without accepting others' does not trigger a false alert.
+`tailscale.health.issues` still reports the **total** count of health messages
+(including benign ones) for dashboard visibility.
 
 ## Troubleshooting
 
@@ -134,11 +155,29 @@ module.tailscale.tailscale_tailnet_key.this (orphan), after which you can
 remove the provider configuration again.
 ```
 
-To remove it, run the following code:
+This is expected Terraform behavior, not a module bug. The module declares its
+own `provider "tailscale"` (configured from the OAuth variables). Commenting out
+or deleting the module call removes that provider configuration, but the state
+still contains `tailscale_tailnet_key.this`, which that provider created — and
+Terraform needs the provider to destroy it. A resource and its provider
+configuration cannot be removed in the same operation.
+
+**Recommended — destroy the module as a unit while the provider still exists:**
+
+1. Re-add (uncomment) the `module "tailscale"` block.
+2. Destroy it explicitly with `terraform destroy -target=module.tailscale` — this
+   removes both the AWS resources and the Tailscale auth key cleanly.
+3. Remove (comment out / delete) the module block. `terraform plan` should then
+   report no changes.
+
+**Alternative — drop only the orphaned resource from state:**
 
 ```shell
 terraform state rm module.tailscale.tailscale_tailnet_key.this
 ```
+
+This lets the apply proceed, but the auth key is **not** deleted from Tailscale
+(Terraform just forgets it) — revoke it manually in the Admin Console.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -1,73 +1,121 @@
 # Terraform AWS Tailscale Module
-This module is used to deploy a [Tailscale](https://tailscale.com) router instance to set up access from VPC to the
-Tailscale Cloud.
-
-Module logic is the following:
-1. Connect to Tailscale API using the Terraform Provider and Tailscale api token.
-2. Generate Tailscale Auth Key and place it into the instance.
-3. Create an Autoscale Group with a single instance using and connect it to the TailScale network.
+This module deploys a [Tailscale](https://tailscale.com) subnet router on AWS using an Auto Scaling Group and launch template. It authenticates via the Tailscale Terraform provider using an OAuth client and generates an auth key for the instance automatically.
 
 ## Usage
 
-_Please refer to [Tailscale Configuration](#tailscale-configuration) first_
+_Please refer to [Tailscale Configuration](#tailscale-configuration) first._
 
 ```terraform
-module "tailscale" {
-  source            = "registry.terraform.io/hazelops/tailscale/aws"
-  version           = "~>2.0"
-  allowed_cidr_blocks = ["0.0.0.0/0"] # Please lock this down to your specific CIDR
-  ec2_key_pair_name = "default-key"
-  env               = "prod"
-  subnets           = ["subnet-0000000", "subnet-0000000"]
-  vpc_id            = "vpc-0000000"
-  api_token         = "00000000000000000000000000" # Please don't store secrets in plain text
+data "aws_ssm_parameter" "tailscale_oauth_client_id" {
+  name = "/${var.env}/global/tailscale_oauth_client_id"
 }
 
-```
-More examples can be found in the [examples directory](./examples).
+data "aws_ssm_parameter" "tailscale_oauth_client_secret" {
+  name = "/${var.env}/global/tailscale_oauth_client_secret"
+}
 
-## Tailscale Configuration
+module "tailscale" {
+  source  = "registry.terraform.io/hazelops/tailscale/aws"
+  version = "~> 3.0"
 
-1. Create [Tailscale API access token](https://login.tailscale.com/admin/settings/keys) (More info on Access tokens can be found [here](https://tailscale.com/kb/1083/acl-tags#access-tokens)
-2. Add tag to the [ACL control list](https://login.tailscale.com/admin/acls/file). ACL should look like this:
-  ```json
-  {
-  "acls": [
-    {
-      "action": "accept",
-      "ports": [
-        "*:*"
-      ],
-      "users": [
-        "*"
-      ]
-    }
-  ],
-  "tagOwners": {
-    "tag:<your-environment>": []
+  env                           = "prod"
+  vpc_id                        = "vpc-0000000"
+  subnets                       = ["subnet-aaa0001", "subnet-bbb0002"] # Two AZs for HA
+  allowed_cidr_blocks           = ["10.0.0.0/16"]
+  ec2_key_pair_name             = "default-key"
+  tailscale_oauth_client_id     = data.aws_ssm_parameter.tailscale_oauth_client_id.value
+  tailscale_oauth_client_secret = data.aws_ssm_parameter.tailscale_oauth_client_secret.value
+
+  asg = {
+    min_size = 2
+    max_size = 2
   }
 }
 ```
 
-Make sure to approve the advertised route:
-1. Go to [Machines](https://login.tailscale.com/admin/machines) page
-2. Find the machine and click on the `...` button.
-3. Select "Edit route settings", check the checkbox and then click "Save".
+More examples can be found in the [examples directory](./examples).
 
-**_The tag must be added to the ACL to disable automatic key expiration!_**
+## Tailscale Configuration
 
-Default parameter for tag is `tag:<your-environment>`.
+### 1. Create an OAuth client
 
-More examples can be found in [Tailscale Tag Docs](https://tailscale.com/kb/1068/acl-tags#defining-a-tag).
+Go to the [Tailscale Admin Console](https://login.tailscale.com/admin/settings/oauth) → **Settings** → **OAuth clients** → **Generate OAuth client**.
 
-3. Create AWS SSM Parameter using the obtained Tailscale API access token. For example, use the following path
-   pattern: `<env-name>/global/tailscale_api_token`. For more information please refer
-   to [AWS Docs](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-create-console.html).
-4. Add data source to Terraform code like in the [example configuration main.tf file](./examples/minimum/main.tf).
-5. In the module call parameters, set `api_token` variable like in
-   the [example configuration main.tf file](./examples/minimum/main.tf).
-6. Alternatively Tailscale API token could be set as string, but this is very unsafe, therefore it is *
-   *_highly not recommended_** to do this.
+Set the scope to **Auth Keys — Write** and select the tags used by the module (e.g. `tag:<your-environment>`).
+
+Save the **Client ID** and **Client Secret**.
+
+### 2. Store credentials in SSM Parameter Store
+
+Create two SSM parameters (SecureString recommended for the secret):
+
+```bash
+aws ssm put-parameter \
+  --name "/<env>/global/tailscale_oauth_client_id" \
+  --type "String" \
+  --value "<your-client-id>"
+
+aws ssm put-parameter \
+  --name "/<env>/global/tailscale_oauth_client_secret" \
+  --type "SecureString" \
+  --value "<your-client-secret>"
+```
+
+### 3. Configure the ACL
+
+Add the tag and `autoApprovers` to your [ACL policy](https://login.tailscale.com/admin/acls/file):
+
+```json
+{
+  "acls": [
+    {
+      "action": "accept",
+      "src": ["*"],
+      "dst": ["*:*"]
+    }
+  ],
+  "tagOwners": {
+    "tag:<your-environment>": []
+  },
+  "autoApprovers": {
+    "routes": {
+      "10.0.0.0/16": ["tag:<your-environment>"]
+    }
+  }
+}
+```
+
+With `autoApprovers` configured, advertised routes are approved automatically — no manual approval in the admin console is needed.
+
+**The tag must be added to the ACL to disable automatic key expiration.**
+
+More info on tags: [Tailscale ACL Tags](https://tailscale.com/kb/1068/acl-tags#defining-a-tag).
+
+## High Availability
+
+Running two instances (e.g. `asg = { min_size = 2, max_size = 2 }`) in subnets across two Availability Zones provides automatic failover. Both instances advertise the same routes, and Tailscale handles failover transparently with ~15 seconds of downtime.
+
+**Prerequisite:** `autoApprovers` must be configured in the Tailscale ACL (see [Configure the ACL](#3-configure-the-acl)). Without it, routes require manual approval and failover will not work automatically.
+
+**Recovery cycle:** When one instance fails, Tailscale switches traffic to the surviving instance. The ASG detects the failure and launches a replacement. The new instance automatically joins the Tailnet, advertises the same routes, and becomes the standby node — restoring the HA pair without manual intervention.
+
+## Datadog Monitoring (Optional)
+
+Enable Datadog Agent with a custom Tailscale health check:
+
+```terraform
+module "tailscale" {
+  # ... other variables ...
+  datadog_enabled = true
+  datadog_api_key = var.datadog_api_key
+}
+```
+
+This installs Datadog Agent 7 and a custom check that emits:
+- `tailscale.self.online` (gauge, 0/1)
+- `tailscale.peers.count` (gauge)
+- `tailscale.health.issues` (gauge)
+- `tailscale.up` (service check, OK or CRITICAL)
 
 ## Troubleshooting
 
@@ -99,14 +147,14 @@ terraform state rm module.tailscale.tailscale_tailnet_key.this
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=4.30.0 |
-| <a name="requirement_tailscale"></a> [tailscale](#requirement\_tailscale) | 0.18 |
+| <a name="requirement_tailscale"></a> [tailscale](#requirement\_tailscale) | ~> 0.29 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >=4.30.0 |
-| <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | 0.18 |
+| <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | ~> 0.29 |
 
 ## Modules
 
@@ -122,7 +170,7 @@ No modules.
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [tailscale_tailnet_key.this](https://registry.terraform.io/providers/tailscale/tailscale/0.18/docs/resources/tailnet_key) | resource |
+| [tailscale_tailnet_key.this](https://registry.terraform.io/providers/tailscale/tailscale/latest/docs/resources/tailnet_key) | resource |
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
@@ -132,8 +180,9 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of network subnets that are allowed. According to PCI-DSS, CIS AWS and SOC2 providing a default wide-open CIDR is not secure. | `list(string)` | n/a | yes |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | Optional AMI ID for Tailscale instance. Otherwise latest Amazon Linux will be used. One might want to lock this down to avoid unexpected upgrades. | `string` | `""` | no |
-| <a name="input_api_token"></a> [api\_token](#input\_api\_token) | Tailscale API access token | `string` | n/a | yes |
 | <a name="input_asg"></a> [asg](#input\_asg) | Scaling settings of an Auto Scaling Group | `map(any)` | <pre>{<br>  "max_size": 1,<br>  "min_size": 1<br>}</pre> | no |
+| <a name="input_datadog_api_key"></a> [datadog\_api\_key](#input\_datadog\_api\_key) | Datadog API key (required if datadog\_enabled is true) | `string` | `""` | no |
+| <a name="input_datadog_enabled"></a> [datadog\_enabled](#input\_datadog\_enabled) | Whether to enable Datadog Agent monitoring on the Tailscale instance | `bool` | `false` | no |
 | <a name="input_ec2_key_pair_name"></a> [ec2\_key\_pair\_name](#input\_ec2\_key\_pair\_name) | EC2 key pair name to use for Tailscale instance | `string` | n/a | yes |
 | <a name="input_env"></a> [env](#input\_env) | Environment name (typically dev/prod) | `string` | n/a | yes |
 | <a name="input_ext_security_groups"></a> [ext\_security\_groups](#input\_ext\_security\_groups) | External security groups to add to the Tailscale instance | `list(any)` | `[]` | no |
@@ -144,10 +193,12 @@ No modules.
 | <a name="input_key_reusable"></a> [key\_reusable](#input\_key\_reusable) | Indicates whether the key is reusable | `bool` | `true` | no |
 | <a name="input_monitoring_enabled"></a> [monitoring\_enabled](#input\_monitoring\_enabled) | Whether to enable monitoring for the Auto Scaling Group | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for Tailscale instance | `string` | `"tailscale-router"` | no |
-| <a name="input_public_ip_enabled"></a> [public\_ip\_enabled](#input\_public\_ip\_enabled) | Wheter to enable a public IP for Tailscale instance | `bool` | `false` | no |
-| <a name="input_ssm_role_arn"></a> [ssm\_role\_arn](#input\_ssm\_role\_arn) | SSM role to attach to a Tailscale instance | `string` | `"arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"` | no |
-| <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets where the Taiscale instance will be placed. It is recommended to use a private subnet for better security. | `list(string)` | n/a | yes |
+| <a name="input_public_ip_enabled"></a> [public\_ip\_enabled](#input\_public\_ip\_enabled) | Whether to enable a public IP for Tailscale instance | `bool` | `false` | no |
+| <a name="input_ssm_role_arn"></a> [ssm\_role\_arn](#input\_ssm\_role\_arn) | SSM policy ARN to attach to the Tailscale instance IAM role | `string` | `"arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"` | no |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets where the Tailscale instance will be placed. It is recommended to use a private subnet for better security. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | AWS tags for the Tailscale instance | `map(string)` | `{}` | no |
+| <a name="input_tailscale_oauth_client_id"></a> [tailscale\_oauth\_client\_id](#input\_tailscale\_oauth\_client\_id) | Tailscale OAuth client ID | `string` | n/a | yes |
+| <a name="input_tailscale_oauth_client_secret"></a> [tailscale\_oauth\_client\_secret](#input\_tailscale\_oauth\_client\_secret) | Tailscale OAuth client secret | `string` | n/a | yes |
 | <a name="input_tailscale_tags"></a> [tailscale\_tags](#input\_tailscale\_tags) | List of Tailscale tags for the Tailnet device. It would be automatically tagged when it is authenticated with this key | `list(string)` | `[]` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the Tailscale instance will be placed | `string` | n/a | yes |
 

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -1,35 +1,45 @@
 variable "env" {}
 variable "vpc_id" {}
 variable "subnets" {}
-variable "ec2_key_pair_name" {}
-variable "ssh_public_key" {}
 variable "vpc_cidr_block" {}
-variable "ssh_key_id" {}
 variable "aws_key_name" {}
+variable "datadog_api_key" { default = "" }
 
-# Obtain Tailscale auth key from AWS SSM Parameter Store
-data "aws_ssm_parameter" "tailscale_api_token" {
-  name = "/${var.env}/global/tailscale_api_token"
+data "aws_ssm_parameter" "tailscale_oauth_client_id" {
+  name = "/${var.env}/global/tailscale_oauth_client_id"
+}
+
+data "aws_ssm_parameter" "tailscale_oauth_client_secret" {
+  name = "/${var.env}/global/tailscale_oauth_client_secret"
 }
 
 module "tailscale" {
-  source              = "registry.terraform.io/hazelops/tailscale/aws"
-  version             = "~>2.0"
-  name                = "tailscale-instance"
-  allowed_cidr_blocks = [var.vpc_cidr_block]
-  ec2_key_pair_name   = var.aws_key_name
-  env                 = var.env
-  subnets             = var.subnets
-  vpc_id              = var.vpc_id
-  public_ip_enabled   = true
-  ami_id              = "ami-0e1c5d8c23330dee3"
-  instance_type       = "t4g.nano"
-  tailscale_api_token = data.aws_ssm_parameter.tailscale_api_token.value # Please don't store secrets in plain text
-  monitoring_enabled  = true
-  ext_security_groups = []
-  tags                = ["tag:server"]
-  key_expiry          = 7776000
-  key_reusable        = true
-  key_ephemeral       = true
-  key_preauthorized   = true
+  source                        = "registry.terraform.io/hazelops/tailscale/aws"
+  version                       = "~> 3.0"
+  name                          = "tailscale-router"
+  allowed_cidr_blocks           = [var.vpc_cidr_block]
+  ec2_key_pair_name             = var.aws_key_name
+  env                           = var.env
+  subnets                       = var.subnets
+  vpc_id                        = var.vpc_id
+  public_ip_enabled             = true
+  instance_type                 = "t4g.nano"
+  tailscale_oauth_client_id     = data.aws_ssm_parameter.tailscale_oauth_client_id.value
+  tailscale_oauth_client_secret = data.aws_ssm_parameter.tailscale_oauth_client_secret.value
+  monitoring_enabled            = true
+  ext_security_groups           = []
+  asg = {
+    min_size = 2
+    max_size = 2
+  }
+  tailscale_tags = ["tag:server"]
+  tags = {
+    Team = "infrastructure"
+  }
+  key_expiry        = 7776000
+  key_reusable      = true
+  key_ephemeral     = true
+  key_preauthorized = true
+  datadog_enabled   = true
+  datadog_api_key   = var.datadog_api_key
 }

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -24,6 +24,7 @@ module "tailscale" {
   vpc_id                        = var.vpc_id
   public_ip_enabled             = true
   instance_type                 = "t4g.nano"
+  ami_id                        = "ami-0e1c5d8c23330dee3"
   tailscale_oauth_client_id     = data.aws_ssm_parameter.tailscale_oauth_client_id.value
   tailscale_oauth_client_secret = data.aws_ssm_parameter.tailscale_oauth_client_secret.value
   monitoring_enabled            = true

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -1,24 +1,25 @@
 variable "env" {}
 variable "vpc_id" {}
 variable "subnets" {}
-variable "ec2_key_pair_name" {}
-variable "ssh_public_key" {}
 variable "vpc_cidr_block" {}
-variable "ssh_key_id" {}
 variable "aws_key_name" {}
 
-# Obtain Tailscale api key from AWS SSM Parameter Store
-data "aws_ssm_parameter" "tailscale_api_token" {
-  name = "/${var.env}/global/tailscale_api_token"
+data "aws_ssm_parameter" "tailscale_oauth_client_id" {
+  name = "/${var.env}/global/tailscale_oauth_client_id"
+}
+
+data "aws_ssm_parameter" "tailscale_oauth_client_secret" {
+  name = "/${var.env}/global/tailscale_oauth_client_secret"
 }
 
 module "tailscale" {
-  source              = "registry.terraform.io/hazelops/tailscale/aws"
-  version             = "~>2.0"
-  allowed_cidr_blocks = [var.vpc_cidr_block]
-  ec2_key_pair_name   = var.aws_key_name
-  env                 = var.env
-  subnets             = var.subnets
-  vpc_id              = var.vpc_id
-  api_token           = data.aws_ssm_parameter.tailscale_api_token.value # Please don't store secrets in plain text
+  source                        = "registry.terraform.io/hazelops/tailscale/aws"
+  version                       = "~> 3.0"
+  allowed_cidr_blocks           = [var.vpc_cidr_block]
+  ec2_key_pair_name             = var.aws_key_name
+  env                           = var.env
+  subnets                       = var.subnets
+  vpc_id                        = var.vpc_id
+  tailscale_oauth_client_id     = data.aws_ssm_parameter.tailscale_oauth_client_id.value
+  tailscale_oauth_client_secret = data.aws_ssm_parameter.tailscale_oauth_client_secret.value
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  name = "${var.env}-${var.name}"
+  name          = "${var.env}-${var.name}"
   instance_arch = can(regex("\\w\\dg\\..*", var.instance_type)) ? "arm64" : "x86_64"
 }

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,8 @@
 resource "aws_autoscaling_group" "this" {
   name                = local.name
   vpc_zone_identifier = var.subnets
-  min_size            = var.asg["max_size"]
-  max_size            = var.asg["min_size"]
+  min_size            = var.asg["min_size"]
+  max_size            = var.asg["max_size"]
   launch_template {
     id = aws_launch_template.this.id
   }
@@ -40,6 +40,9 @@ resource "aws_launch_template" "this" {
     auth_key         = tailscale_tailnet_key.this.key
     advertise_routes = join(",", var.allowed_cidr_blocks)
     hostname         = local.name
+    datadog_enabled  = var.datadog_enabled
+    datadog_api_key  = var.datadog_api_key
+    env              = var.env
   }))
   update_default_version = true
   monitoring {

--- a/output.tf
+++ b/output.tf
@@ -1,5 +1,5 @@
 output "security_group_id" {
-  value = element(aws_security_group.this.*.id, 0)
+  value = aws_security_group.this.id
 }
 
 output "autoscaling_group_id" {

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,4 @@
 provider "tailscale" {
-  api_key = var.api_token
+  oauth_client_id     = var.tailscale_oauth_client_id
+  oauth_client_secret = var.tailscale_oauth_client_secret
 }

--- a/templates/ec2_user_data.tpl.yml
+++ b/templates/ec2_user_data.tpl.yml
@@ -24,7 +24,27 @@ write_files:
     content: |
       import json
       import subprocess
+      from datetime import datetime, timezone
       from datadog_checks.base import AgentCheck
+
+
+      def _age_seconds(ts):
+          # Age of the last handshake in seconds; None if there was never one.
+          if not ts or ts.startswith("0001"):
+              return None
+          s = ts.rstrip("Z")
+          if "." in s:
+              head, frac = s.split(".", 1)
+              s = head + "." + frac[:6]
+              fmt = "%Y-%m-%dT%H:%M:%S.%f"
+          else:
+              fmt = "%Y-%m-%dT%H:%M:%S"
+          try:
+              dt = datetime.strptime(s, fmt).replace(tzinfo=timezone.utc)
+          except ValueError:
+              return None
+          return (datetime.now(timezone.utc) - dt).total_seconds()
+
 
       class TailscaleCheck(AgentCheck):
           def check(self, instance):
@@ -35,11 +55,47 @@ write_files:
                   )
                   status = json.loads(result.stdout)
 
-                  online = 1 if status.get("Self", {}).get("Online", False) else 0
+                  self_node = status.get("Self", {}) or {}
+                  online = 1 if self_node.get("Online", False) else 0
                   self.gauge("tailscale.self.online", online)
 
-                  peers = status.get("Peer", {})
+                  # Subnets this node serves as primary (approved and active).
+                  # In HA: 1 on the active node, 0 on the standby.
+                  primary_routes = self_node.get("PrimaryRoutes") or []
+                  self.gauge("tailscale.routes.primary_count", len(primary_routes))
+
+                  peers = status.get("Peer", {}) or {}
                   self.gauge("tailscale.peers.count", len(peers))
+
+                  online_peers = 0
+                  direct_peers = 0
+                  relayed_peers = 0
+                  for pkey, p in peers.items():
+                      host = p.get("HostName") or p.get("DNSName") or pkey[:12]
+                      ptags = ["peer:" + host]
+
+                      p_online = 1 if p.get("Online") else 0
+                      online_peers += p_online
+                      self.gauge("tailscale.peer.online", p_online, tags=ptags)
+                      self.gauge("tailscale.peer.rx_bytes", p.get("RxBytes", 0), tags=ptags)
+                      self.gauge("tailscale.peer.tx_bytes", p.get("TxBytes", 0), tags=ptags)
+
+                      # Relay == "" -> direct connection, otherwise traffic goes via a DERP relay.
+                      is_direct = 1 if p.get("Relay", "") == "" else 0
+                      self.gauge("tailscale.peer.direct", is_direct, tags=ptags)
+                      if p_online:
+                          if is_direct:
+                              direct_peers += 1
+                          else:
+                              relayed_peers += 1
+
+                      age = _age_seconds(p.get("LastHandshake"))
+                      if age is not None:
+                          self.gauge("tailscale.peer.last_handshake_age_seconds", age, tags=ptags)
+
+                  self.gauge("tailscale.peers.online", online_peers)
+                  self.gauge("tailscale.peers.direct", direct_peers)
+                  self.gauge("tailscale.peers.relayed", relayed_peers)
 
                   health = status.get("Health") or []
                   self.gauge("tailscale.health.issues", len(health))

--- a/templates/ec2_user_data.tpl.yml
+++ b/templates/ec2_user_data.tpl.yml
@@ -100,10 +100,23 @@ write_files:
                   health = status.get("Health") or []
                   self.gauge("tailscale.health.issues", len(health))
 
-                  if online and len(health) == 0:
-                      self.service_check("tailscale.up", AgentCheck.OK)
+                  # Some health messages are benign for a subnet router (e.g. it
+                  # advertises routes but does not accept others') and must not
+                  # raise a false alert.
+                  benign = ("--accept-routes is false",)
+                  real_issues = [h for h in health
+                                 if not any(b in h for b in benign)]
+
+                  # CRITICAL only when the node is actually offline. Real
+                  # (non-benign) health issues degrade to WARNING; otherwise OK.
+                  if not online:
+                      self.service_check("tailscale.up", AgentCheck.CRITICAL,
+                                         message="tailscaled reports node offline")
+                  elif real_issues:
+                      self.service_check("tailscale.up", AgentCheck.WARNING,
+                                         message="; ".join(real_issues))
                   else:
-                      self.service_check("tailscale.up", AgentCheck.CRITICAL)
+                      self.service_check("tailscale.up", AgentCheck.OK)
               except Exception as e:
                   self.service_check("tailscale.up", AgentCheck.CRITICAL, message=str(e))
                   self.gauge("tailscale.self.online", 0)

--- a/templates/ec2_user_data.tpl.yml
+++ b/templates/ec2_user_data.tpl.yml
@@ -48,6 +48,9 @@ write_files:
 
       class TailscaleCheck(AgentCheck):
           def check(self, instance):
+              # Instance-level tags from conf.yaml are NOT auto-applied to custom
+              # checks, so read them here and attach to every metric / service check.
+              base_tags = list(instance.get("tags", []))
               try:
                   result = subprocess.run(
                       ["sudo", "/usr/bin/tailscale", "status", "--json"],
@@ -57,22 +60,22 @@ write_files:
 
                   self_node = status.get("Self", {}) or {}
                   online = 1 if self_node.get("Online", False) else 0
-                  self.gauge("tailscale.self.online", online)
+                  self.gauge("tailscale.self.online", online, tags=base_tags)
 
                   # Subnets this node serves as primary (approved and active).
                   # In HA: 1 on the active node, 0 on the standby.
                   primary_routes = self_node.get("PrimaryRoutes") or []
-                  self.gauge("tailscale.routes.primary_count", len(primary_routes))
+                  self.gauge("tailscale.routes.primary_count", len(primary_routes), tags=base_tags)
 
                   peers = status.get("Peer", {}) or {}
-                  self.gauge("tailscale.peers.count", len(peers))
+                  self.gauge("tailscale.peers.count", len(peers), tags=base_tags)
 
                   online_peers = 0
                   direct_peers = 0
                   relayed_peers = 0
                   for pkey, p in peers.items():
                       host = p.get("HostName") or p.get("DNSName") or pkey[:12]
-                      ptags = ["peer:" + host]
+                      ptags = base_tags + ["peer:" + host]
 
                       p_online = 1 if p.get("Online") else 0
                       online_peers += p_online
@@ -93,12 +96,12 @@ write_files:
                       if age is not None:
                           self.gauge("tailscale.peer.last_handshake_age_seconds", age, tags=ptags)
 
-                  self.gauge("tailscale.peers.online", online_peers)
-                  self.gauge("tailscale.peers.direct", direct_peers)
-                  self.gauge("tailscale.peers.relayed", relayed_peers)
+                  self.gauge("tailscale.peers.online", online_peers, tags=base_tags)
+                  self.gauge("tailscale.peers.direct", direct_peers, tags=base_tags)
+                  self.gauge("tailscale.peers.relayed", relayed_peers, tags=base_tags)
 
                   health = status.get("Health") or []
-                  self.gauge("tailscale.health.issues", len(health))
+                  self.gauge("tailscale.health.issues", len(health), tags=base_tags)
 
                   # Some health messages are benign for a subnet router (e.g. it
                   # advertises routes but does not accept others') and must not
@@ -111,15 +114,18 @@ write_files:
                   # (non-benign) health issues degrade to WARNING; otherwise OK.
                   if not online:
                       self.service_check("tailscale.up", AgentCheck.CRITICAL,
+                                         tags=base_tags,
                                          message="tailscaled reports node offline")
                   elif real_issues:
                       self.service_check("tailscale.up", AgentCheck.WARNING,
+                                         tags=base_tags,
                                          message="; ".join(real_issues))
                   else:
-                      self.service_check("tailscale.up", AgentCheck.OK)
+                      self.service_check("tailscale.up", AgentCheck.OK, tags=base_tags)
               except Exception as e:
-                  self.service_check("tailscale.up", AgentCheck.CRITICAL, message=str(e))
-                  self.gauge("tailscale.self.online", 0)
+                  self.service_check("tailscale.up", AgentCheck.CRITICAL,
+                                     tags=base_tags, message=str(e))
+                  self.gauge("tailscale.self.online", 0, tags=base_tags)
   - path: /etc/datadog-agent/conf.d/tailscale.d/conf.yaml
     permissions: '0644'
     content: |

--- a/templates/ec2_user_data.tpl.yml
+++ b/templates/ec2_user_data.tpl.yml
@@ -1,21 +1,75 @@
 #cloud-config
 hostname: ${hostname}
-yum_repos:
-  tailscale-stable:
-    name: tailscale-stable
-    enabled: true
-    repo_gpgcheck: true
-    gpgcheck: false
-    baseurl: https://pkgs.tailscale.com/stable/amazon-linux/2/$basearch
-    gpgkey: https://pkgs.tailscale.com/stable/amazon-linux/2/repo.gpg
-packages:
-  - tailscale
 write_files:
+  - path: /etc/yum.repos.d/tailscale.repo
+    content: |
+      [tailscale-stable]
+      name=Tailscale stable
+      baseurl=https://pkgs.tailscale.com/stable/amazon-linux/2023/$basearch
+      enabled=1
+      repo_gpgcheck=1
+      gpgcheck=0
+      gpgkey=https://pkgs.tailscale.com/stable/amazon-linux/2023/repo.gpg
   - path: /etc/sysctl.conf
     content: |
       net.ipv4.ip_forward = 1
       net.ipv6.conf.all.forwarding = 1
+%{ if datadog_enabled }
+  - path: /etc/sudoers.d/dd-agent-tailscale
+    permissions: '0440'
+    content: |
+      dd-agent ALL=(root) NOPASSWD: /usr/bin/tailscale status --json
+  - path: /etc/datadog-agent/checks.d/tailscale.py
+    permissions: '0644'
+    content: |
+      import json
+      import subprocess
+      from datadog_checks.base import AgentCheck
+
+      class TailscaleCheck(AgentCheck):
+          def check(self, instance):
+              try:
+                  result = subprocess.run(
+                      ["sudo", "/usr/bin/tailscale", "status", "--json"],
+                      capture_output=True, text=True, timeout=10
+                  )
+                  status = json.loads(result.stdout)
+
+                  online = 1 if status.get("Self", {}).get("Online", False) else 0
+                  self.gauge("tailscale.self.online", online)
+
+                  peers = status.get("Peer", {})
+                  self.gauge("tailscale.peers.count", len(peers))
+
+                  health = status.get("Health") or []
+                  self.gauge("tailscale.health.issues", len(health))
+
+                  if online and len(health) == 0:
+                      self.service_check("tailscale.up", AgentCheck.OK)
+                  else:
+                      self.service_check("tailscale.up", AgentCheck.CRITICAL)
+              except Exception as e:
+                  self.service_check("tailscale.up", AgentCheck.CRITICAL, message=str(e))
+                  self.gauge("tailscale.self.online", 0)
+  - path: /etc/datadog-agent/conf.d/tailscale.d/conf.yaml
+    permissions: '0644'
+    content: |
+      init_config:
+      instances:
+        - min_collection_interval: 30
+          tags:
+            - env:${env}
+            - service:tailscale-router
+%{ endif }
+packages:
+  - tailscale
+  - curl
 runcmd:
   - sysctl -p /etc/sysctl.conf
   - systemctl enable --now tailscaled
   - tailscale up --authkey "${auth_key}" --advertise-routes "${advertise_routes}" --hostname "${hostname}"
+%{ if datadog_enabled }
+  - DD_API_KEY="${datadog_api_key}" DD_SITE="datadoghq.com" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+  - chown -R dd-agent:dd-agent /etc/datadog-agent/checks.d /etc/datadog-agent/conf.d
+  - systemctl restart datadog-agent
+%{ endif }

--- a/templates/ec2_user_data.tpl.yml
+++ b/templates/ec2_user_data.tpl.yml
@@ -63,7 +63,6 @@ write_files:
 %{ endif }
 packages:
   - tailscale
-  - curl
 runcmd:
   - sysctl -p /etc/sysctl.conf
   - systemctl enable --now tailscaled

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "ec2_key_pair_name" {
 
 variable "subnets" {
   type        = list(string)
-  description = "Subnets where the Taiscale instance will be placed. It is recommended to use a private subnet for better security."
+  description = "Subnets where the Tailscale instance will be placed. It is recommended to use a private subnet for better security."
 }
 
 variable "ami_id" {
@@ -38,7 +38,7 @@ variable "instance_type" {
 variable "public_ip_enabled" {
   type        = bool
   default     = false
-  description = "Wheter to enable a public IP for Tailscale instance"
+  description = "Whether to enable a public IP for Tailscale instance"
 }
 
 variable "ext_security_groups" {
@@ -54,8 +54,8 @@ variable "allowed_cidr_blocks" {
 
 variable "ssm_role_arn" {
   type        = string
-  default     = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
-  description = "SSM role to attach to a Tailscale instance"
+  default     = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  description = "SSM policy ARN to attach to the Tailscale instance IAM role"
 }
 
 variable "asg" {
@@ -73,9 +73,15 @@ variable "monitoring_enabled" {
   description = "Whether to enable monitoring for the Auto Scaling Group"
 }
 
-variable "api_token" {
+variable "tailscale_oauth_client_id" {
   type        = string
-  description = "Tailscale API access token"
+  description = "Tailscale OAuth client ID"
+}
+
+variable "tailscale_oauth_client_secret" {
+  type        = string
+  sensitive   = true
+  description = "Tailscale OAuth client secret"
 }
 
 variable "key_expiry" {
@@ -109,7 +115,20 @@ variable "tailscale_tags" {
 }
 
 variable "tags" {
-    type        = map(string)
-    default     = {}
-    description = "AWS tags for the Tailscale instance"
+  type        = map(string)
+  default     = {}
+  description = "AWS tags for the Tailscale instance"
+}
+
+variable "datadog_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether to enable Datadog Agent monitoring on the Tailscale instance"
+}
+
+variable "datadog_api_key" {
+  type        = string
+  default     = ""
+  sensitive   = true
+  description = "Datadog API key (required if datadog_enabled is true)"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     tailscale = {
       source  = "tailscale/tailscale"
-      version = "0.18"
+      version = "~> 0.29"
     }
   }
   required_version = ">=1.2.0"


### PR DESCRIPTION
#### What's new:

-  api_token replaced with tailscale_oauth_client_id / tailscale_oauth_client_secret (OAuth clients don't expire). 
- ASG min/max swap, deprecated SSM policy ARN, Tailscale repo URL updated for AL2023.
- Two instances in separate AZs with asg = { min_size = 2, max_size = 2 } give automatic failover (~15s). Requires autoApprovers in Tailscale ACL.
- Added  Datadog monitoring (optional)
- Tailscale provider bumped from 0.18 to ~> 0.29.

#### Testing done: 

Deploy succesful:
<img width="818" height="727" alt="Screenshot 2026-06-23 at 17 06 36" src="https://github.com/user-attachments/assets/d27b8266-6dfc-4890-8266-48b025a420c5" />
<img width="800" height="178" alt="Screenshot 2026-06-23 at 17 06 42" src="https://github.com/user-attachments/assets/14205345-456e-4533-88c3-8b615381866b" />
<img width="717" height="382" alt="Screenshot 2026-06-23 at 17 06 51" src="https://github.com/user-attachments/assets/80f8743e-eda2-4f2e-a399-b1c361b8658c" />
<img width="690" height="962" alt="Screenshot 2026-06-23 at 17 07 00" src="https://github.com/user-attachments/assets/e8e1eee1-5521-4208-9610-8a9415f1a1ef" />
<img width="718" height="102" alt="Screenshot 2026-06-23 at 17 07 31" src="https://github.com/user-attachments/assets/f3f405ef-0874-42ba-8af1-5d94d717ae66" />

AWS EC2 console: 
<img width="1177" height="124" alt="Screenshot 2026-06-23 at 17 17 06" src="https://github.com/user-attachments/assets/03839ae4-ecae-4ff0-8454-2fbec263c959" />

Tailscale console:
<img width="1257" height="188" alt="Screenshot 2026-06-23 at 17 16 51" src="https://github.com/user-attachments/assets/56fa2bce-229e-421c-884d-826a5e859047" />
